### PR TITLE
[CM-757] Create a SwiftLint Plugin for a Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,20 +16,28 @@ let package = Package(
             targets: ["YCatalogViewer"]
         )
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .binaryTarget(
+            name: "SwiftLintBinary",
+            url: "https://github.com/realm/SwiftLint/releases/download/0.47.1/SwiftLintBinary-macos.artifactbundle.zip",
+            checksum: "82ef90b7d76b02e41edd73423687d9cedf0bb9849dcbedad8df3a461e5a7b555"
+        ),
+        .plugin(
+            name: "SwiftLint",
+            capability: .buildTool(),
+            dependencies: ["SwiftLintBinary"]
+        ),
         .target(
             name: "YCatalogViewer",
-            dependencies: []
+            dependencies: [],
+            plugins: ["SwiftLint"]
         ),
         .testTarget(
             name: "YCatalogViewerTests",
-            dependencies: ["YCatalogViewer"]
+            dependencies: ["YCatalogViewer"],
+            plugins: ["SwiftLint"]
         )
     ]
 )

--- a/Plugins/SwiftLint/main.swift
+++ b/Plugins/SwiftLint/main.swift
@@ -1,0 +1,30 @@
+//
+//  main.swift
+//  YCatalogViewer
+//
+//  Created by Tim Barett on 7/20/22.
+//  Copyright © 2021 Y Media Labs. All rights reserved.
+//
+
+import PackagePlugin
+
+@main
+struct SwiftLint: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        [
+            .buildCommand(
+                displayName: "Linting \(target.name)...",
+                executable: try context.tool(named: "swiftlint").path,
+                arguments: [
+                    "lint",
+                    "--in-process-sourcekit",
+                    "--config",
+                    "\(context.package.directory.string)/.swiftlint.yml",
+                    "--path",
+                    target.directory.string
+                ],
+                environment: [:]
+            )
+        ]
+    }
+}


### PR DESCRIPTION
### Introduction
Add `SwiftLint` plugin to Swift Package.

### Purpose
In order to see warnings and errors in Xcode when using `SwiftLint` in a Swift Package, we need to create a plugin that will run the `SwiftLint` tool at build time. This PR creates a plugin that will do that by using the `SwiftLint` binary. Using the binary instead of pulling in the `SwiftLint` package as a dependency will reduce the build time. In the future, we could pull this out into its own package to be used in all our swift packages. This is possible today but there are issues in Xcode that prevent it from reliably showing warnings in Xcode. This is being resolved in Xcode 14 and should be out in the Fall
<img width="1792" alt="Screen Shot 2022-07-21 at 8 00 45 AM" src="https://user-images.githubusercontent.com/107420896/180246855-89ec577f-33bd-4a89-9f92-90f924d66e61.png">
.