### PR TITLE
[CM-772] Add Jazzy configuration

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,0 +1,16 @@
+author: 'Y Media Labs'
+author_url: https://yml.co
+min_acl: public
+hide_documentation_coverage: false
+theme: fullwidth
+output: ./docs
+documentation: ./*.md
+swift_build_tool: xcodebuild
+module: YCatalogViewer
+xcodebuild_arguments:
+  - -scheme
+  - YCatalogViewer
+  - -sdk
+  - iphonesimulator
+  - -destination
+  - 'platform=iOS Simulator,name=iPhone 13'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,95 @@
 # Y—Catalog-Viewer
 A standalone catalog viewer package that intelligently displays design components.
+
+Requirements
+----------
+
+### Jazzy (documentation)
+```
+sudo gem install jazzy
+```
+
+Setup
+----------
+
+Open `Package.swift` in Xcode.
+
+Contributing to Y—Catalog-Viewer
+----------
+
+### Versioning strategy
+
+We utilize [semantic versioning](https://semver.org).
+
+```
+{major}.{minor}.{patch}
+```
+
+e.g.
+
+```
+1.0.5
+```
+
+### Branching strategy
+
+We utilize a simplified branching strategy for our frameworks.
+
+* main (and development) branch is `main`
+* both feature (and bugfix) branches branch off of `main`
+* feature (and bugfix) branches are merged back into `main` as they are completed and approved.
+* `main` gets tagged with an updated version # for each release
+ 
+### Branch naming conventions:
+
+```
+feature/{ticket-number}-{short-description}
+bugfix/{ticket-number}-{short-description}
+```
+e.g.
+```
+feature/CM-44-button
+bugfix/CM-236-textview-color
+```
+
+### Pull Requests
+
+Prior to submitting a pull request you should:
+
+1. Compile and ensure there are no warnings and no errors (this includes warnings from SwiftLint).
+2. Run all unit tests and confirm that everything passes.
+3. Check unit test coverage and confirm that all new / modified code is fully covered.
+4. Run `jazzy` from the command line and confirm that you have 100% documentation coverage.
+5. Consider using `git rebase -i HEAD~{commit-count}` to squash your last {commit-count} commits together into functional chunks.
+6. If HEAD of the parent branch (typically `main`) has been updated since you created your branch, use `git rebase main` to rebase your branch.
+    * _Never_ merge the parent branch into your branch.
+    * _Always_ rebase your branch off of the parent branch.
+
+When submitting a pull request:
+
+* Use the [provided pull request template](PULL_REQUEST_TEMPLATE.md) and populate the Introduction, Purpose, and Scope fields at a minimum.
+* If you're submitting before and after screenshots, movies, or GIF's, enter them in a two-column table so that they can be viewed side-by-side.
+
+When merging a pull request:
+
+* Make sure the branch is rebased (not merged) off of the latest HEAD from the parent branch. This keeps our git history easy to read and understand.
+* Make sure the branch is deleted upon merge (should be automatic).
+
+### Releasing new versions
+* Tag the corresponding commit with the new version (e.g. `1.0.5`)
+* Push the local tag to remote
+
+Generating Documentation (via Jazzy)
+----------
+
+You can generate your own local set of documentation directly from the source code using the following command from Terminal:
+```
+jazzy
+```
+This generates a set of documentation under `/docs`. The default configuration is set in the default config file `.jazzy.yaml` file.
+
+To view additional documentation options type:
+```
+jazzy --help
+```
+(Once this repo is made public) A GitHub Action automatically runs each time a commit is pushed to `main` that runs Jazzy to generate the documentation for our GitHub page at: https://yml-org.github.io/ycatalogviewer-ios/

--- a/Sources/YCatalogViewer/YCatalogViewer.swift
+++ b/Sources/YCatalogViewer/YCatalogViewer.swift
@@ -1,5 +1,6 @@
 /// YCatalogViewer struct
 public struct YCatalogViewer {
+    /// Sample text to display
     public private(set) var text = "Hello, World!"
     
     /// init method to intialize instance of struct


### PR DESCRIPTION
## Introduction ##

Once our repo is public, we will use Jazzy together with GitHub Actions to automatically generate documentation that will be hosted at the repo's GitHub Page.

## Purpose ##

Configure Jazzy to build documentation from our Swift Package.

## Scope ##

* Added config file
* Updated README with info about Jazzy (and branching, versioning, and Pull Request procedures)
* Achieve 100% documentation

## Discussion ##

Panchami, during our call Jazzy wasn't finding the undocumented protocols because it was not properly configured (no configuration file). With this in place, then it would let you know which files are missing documentation. You can look in `docs/undocumented.json` to see.

## 📈 Coverage ##

##### Documentation #####
100%
<img width="440" alt="image" src="https://user-images.githubusercontent.com/1037520/180463696-30280206-da72-4268-9215-66e2c03cc1ba.png">
