### PR TITLE
Add GitHub Actions to generate documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+# This is a basic workflow to help you get started with Actions
+
+name: PublishDocumentation
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push events but only for the main branch
+  push:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "deploy_docs"
+  deploy_docs:
+    # The type of runner that the job will run on
+    runs-on: macos-12
+    
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v1
+    - name: Publish Jazzy Docs
+      uses: steven0351/publish-jazzy-docs@v1
+      with:
+        personal_access_token: ${{ secrets.ACCESS_TOKEN }}
+        config: .jazzy.yaml

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -6,10 +6,10 @@ theme: fullwidth
 output: ./docs
 documentation: ./*.md
 swift_build_tool: xcodebuild
-module: YCatalogViewer
+module: YComponentBrowser
 xcodebuild_arguments:
   - -scheme
-  - YCatalogViewer
+  - YComponentBrowser
   - -sdk
   - iphonesimulator
   - -destination

--- a/README.md
+++ b/README.md
@@ -325,4 +325,4 @@ To view additional documentation options type:
 ```
 jazzy --help
 ```
-(Once this repo is made public) A GitHub Action automatically runs each time a commit is pushed to `main` that runs Jazzy to generate the documentation for our GitHub page at: https://yml-org.github.io/ycatalogviewer-ios/
+A GitHub Action automatically runs each time a commit is pushed to `main` that runs Jazzy to generate the documentation for our GitHub page at: https://yml-org.github.io/YComponentBrowser/


### PR DESCRIPTION
## Introduction ##

We need to enable GitHub Actions to generate documentation and publish it to GitHub pages

## Purpose ##

Configure the appropriate actions.

## Scope ##

* Fixed broken jazzy config
* added config for GH action
* updated repo to point to the correct documentation link