### PR TITLE
[CM-997] Add linter rules and fix warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,6 +9,8 @@ opt_in_rules: # some rules are turned off by default, so you need to opt-in
   - empty_count
   - first_where
   - force_unwrapping
+  - implicit_return
+  - missing_docs
   - multiline_arguments
   - multiline_arguments_brackets
   - multiline_function_chains

--- a/Sources/YComponentBrowser/CatalogFactory.swift
+++ b/Sources/YComponentBrowser/CatalogFactory.swift
@@ -45,7 +45,7 @@ public enum CatalogFactory {
         with categories: [Classification],
         navigationTitle: String? = nil
     ) -> UIViewController {
-        return ClassificationViewController(
+        ClassificationViewController(
             datasource: ClassificationDataSource(
                 navigationTitle: navigationTitle,
                 classification: categories

--- a/Sources/YComponentBrowser/ClassificationScene/ClassificationDataSource.swift
+++ b/Sources/YComponentBrowser/ClassificationScene/ClassificationDataSource.swift
@@ -34,12 +34,12 @@ public final class ClassificationDataSource: NSObject, CatalogDataSource {
     
     /// :nodoc:
     public func category(for indexPath: IndexPath) -> Classification {
-        return categories[indexPath.row]
+        categories[indexPath.row]
     }
     
     /// :nodoc:
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return categories.count
+        categories.count
     }
     
     /// :nodoc:

--- a/Sources/YComponentBrowser/ClassificationScene/ClassificationViewController.swift
+++ b/Sources/YComponentBrowser/ClassificationScene/ClassificationViewController.swift
@@ -21,7 +21,7 @@ public final class ClassificationViewController<DataSource: CatalogDataSource>: 
     }
     
     /// :nodoc:
-    public required init?(coder: NSCoder) { return nil }
+    public required init?(coder: NSCoder) { nil }
     
     /// :nodoc:
     public override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Sources/YComponentBrowser/Models/Destinations/CatalogDetailDestination.swift
+++ b/Sources/YComponentBrowser/Models/Destinations/CatalogDetailDestination.swift
@@ -19,7 +19,7 @@ public struct CatalogDetailDestination<View: ContentView>: Destination {
     
     /// Creates a tableview controller that displays the model data within the specified view
     public func getDestinationController() -> UIViewController {
-        return CatalogFactory.createGenericDisplayViewController(
+        CatalogFactory.createGenericDisplayViewController(
             viewType: View.self,
             models: models,
             navigationTitle: navigationTitle

--- a/Sources/YComponentBrowser/Models/Destinations/SubcategoryDetailDestination.swift
+++ b/Sources/YComponentBrowser/Models/Destinations/SubcategoryDetailDestination.swift
@@ -19,6 +19,6 @@ public struct SubcategoryDetailDestination: Destination {
     
     /// Creates a subcategory view controller
     public func getDestinationController() -> UIViewController {
-        return CatalogFactory.createClassificationViewController(with: subcategories, navigationTitle: navigationTitle)
+        CatalogFactory.createClassificationViewController(with: subcategories, navigationTitle: navigationTitle)
     }
 }

--- a/Sources/YComponentBrowser/Protocols/Identifiable.swift
+++ b/Sources/YComponentBrowser/Protocols/Identifiable.swift
@@ -15,5 +15,5 @@ public protocol Identifiable {
 /// Default implementation that returns the object type as the identifier
 public extension Identifiable {
     /// Unique identifier for the type of object
-    static var identifier: String { return "\(self)" }
+    static var identifier: String { "\(self)" }
 }

--- a/Sources/YComponentBrowser/UI Components/Generic Cells/GenericCollectionViewCell.swift
+++ b/Sources/YComponentBrowser/UI Components/Generic Cells/GenericCollectionViewCell.swift
@@ -39,7 +39,7 @@ public final class GenericCollectionViewCell<View: ContentView>: UICollectionVie
     }
     
     /// :nodoc:
-    public required init?(coder: NSCoder) { return nil }
+    public required init?(coder: NSCoder) { nil }
     
     /// :nodoc:
     public override func prepareForReuse() {

--- a/Sources/YComponentBrowser/UI Components/Generic Cells/GenericTableViewCell.swift
+++ b/Sources/YComponentBrowser/UI Components/Generic Cells/GenericTableViewCell.swift
@@ -21,9 +21,7 @@ public final class GenericTableViewCell<View: ContentView>: UITableViewCell, Ide
     }
     
     /// :nodoc:
-    public required init?(coder: NSCoder) {
-        return nil
-    }
+    public required init?(coder: NSCoder) { nil }
     
     /// :nodoc:
     public override func setHighlighted(_ highlighted: Bool, animated: Bool) {

--- a/Sources/YComponentBrowser/UI Components/Generic Controllers/GenericCollectionViewController.swift
+++ b/Sources/YComponentBrowser/UI Components/Generic Controllers/GenericCollectionViewController.swift
@@ -37,7 +37,7 @@ final public class GenericCollectionViewController<View: ContentView>: UICollect
         _ collectionView: UICollectionView,
         numberOfItemsInSection section: Int
     ) -> Int {
-        return models.count
+        models.count
     }
     
     /// :nodoc:

--- a/Sources/YComponentBrowser/UI Components/Generic Controllers/GenericTableViewController.swift
+++ b/Sources/YComponentBrowser/UI Components/Generic Controllers/GenericTableViewController.swift
@@ -28,7 +28,7 @@ final public class GenericTableViewController<View: ContentView>: UITableViewCon
     
     /// :nodoc:
     public override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return models.count
+        models.count
     }
     
     /// :nodoc:

--- a/Tests/YComponentBrowserTests/Models/Categories/CatalogCategoryTest.swift
+++ b/Tests/YComponentBrowserTests/Models/Categories/CatalogCategoryTest.swift
@@ -36,9 +36,7 @@ class Demo: Classification {
 }
 
 class Demodestination: Destination {
-    func getDestinationController() -> UIViewController {
-        return controller
-    }
+    func getDestinationController() -> UIViewController { controller }
     
     var presentationStyle: Presentation
     var navigationTitle: String?


### PR DESCRIPTION
## Introduction
Our style guide requires the use of implicit return and our library team requires full documentation, so we should add linter rules to enforce these things instead of having to spot them during code review.

## Purpose
Update SwiftLint config with `implicit_return` and `missing_docs` rules. Fix any linter violations.

## Scope
* Update `.swiftlint.yml`
* Fix linter violations

## Discussion
YComponentBrowser had multiple violations of the `implicit_return` rule. 

We want to roll out these changes to all of our YML libraries, both in Bitbucket and on GitHub.

Fixes Issue #49 

## 📈 Coverage
Unchanged. And documentation coverage should now be enforced by the linter!
